### PR TITLE
Use primeroz ( FC ) version of dockerize 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.10
+FROM alpine:3.11
 
-ENV DOCKERIZE_VERSION v0.6.1
+ENV DOCKERIZE_VERSION v0.6.1-2
 
 RUN apk add --no-cache bash \
                        curl \
@@ -10,7 +10,7 @@ RUN apk add --no-cache bash \
                        openssl \
                        py3-pip \
     && rm -rf /var/cache/apk/* \
-    && wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && wget https://github.com/primeroz/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && pip3 install yq==2.10.0


### PR DESCRIPTION
* since upstream project is abandonded
  * Support of `-insecure-ssl` flag for wait https connection
* Also upgrade image to alpine 3.11


